### PR TITLE
Fix ovhelper/ov_fb_connect: Use toName correctly

### DIFF
--- a/ovhelper/source/object_helper.c
+++ b/ovhelper/source/object_helper.c
@@ -85,7 +85,7 @@ OV_DLLFNCEXPORT OV_INSTPTR_fb_connection
     return NULL;
   }
   result |= fb_connection_sourceport_set(pconn, fromName);
-  result |= fb_connection_targetport_set(pconn, fromName);
+  result |= fb_connection_targetport_set(pconn, toName);
   result |= Ov_Link(fb_inputconnections, toObj, pconn);
   result |= Ov_Link(fb_outputconnections, fromObj, pconn);
   result |= fb_connection_on_set(pconn, 1);


### PR DESCRIPTION
The previous code version ignored the `toName` parameter and instead used the `fromName` twice, which only resulted in working fb_connections, if the in- and outgoing variables are named equally.